### PR TITLE
Ignore SOL Native (List mint TokenProvider)

### DIFF
--- a/packages/senhub/src/shared/tokenProvider/index.ts
+++ b/packages/senhub/src/shared/tokenProvider/index.ts
@@ -2,7 +2,7 @@ import lunr, { Index } from 'lunr'
 import { TokenListProvider, TokenInfo } from '@solana/spl-token-registry'
 
 import { net, chainId, ChainId, Net } from 'shared/runtime'
-import supplementary, { sntr, sol } from './supplementary'
+import supplementary, { sntr, sol, SOL_ADDRESS } from './supplementary'
 
 class TokenProvider {
   private tokenMap: Map<string, TokenInfo>
@@ -59,7 +59,12 @@ class TokenProvider {
 
   all = async (): Promise<TokenInfo[]> => {
     const [tokenMap] = await this._init()
-    return Array.from(tokenMap.values())
+    const filteredToken: TokenInfo[] = []
+    tokenMap.forEach((token) => {
+      // Ignore SOL Native
+      if (token.address !== SOL_ADDRESS) filteredToken.push(token)
+    })
+    return filteredToken
   }
 
   findByAddress = async (addr: string): Promise<TokenInfo | undefined> => {
@@ -75,7 +80,8 @@ class TokenProvider {
     engine.search(fuzzy).forEach(({ ref }) => {
       if (tokens.findIndex(({ address }) => address === ref) < 0) {
         const token = tokenMap.get(ref)
-        if (token) tokens.push(token)
+        // Ignore SOL Native
+        if (token && token.address !== SOL_ADDRESS) tokens.push(token)
       }
     })
     if (limit === 0) return tokens

--- a/packages/senhub/src/shared/tokenProvider/supplementary.ts
+++ b/packages/senhub/src/shared/tokenProvider/supplementary.ts
@@ -1,9 +1,10 @@
+export const SOL_ADDRESS = '11111111111111111111111111111111'
 // Pseudo native sol info
 // It's for all networks
 export const sol = (chainId: 101 | 102 | 103) => ({
   symbol: 'SOL',
   name: 'Solana',
-  address: '11111111111111111111111111111111',
+  address: SOL_ADDRESS,
   decimals: 9,
   chainId,
   extensions: {


### PR DESCRIPTION
TokenProvider is a list of SPL Tokens. Those are tokens that can perform transactions such as deposit, swap, .... 
So, we should ignore SOL Native in the list mint result of TokenProvider.all and TokenProvider.find function.